### PR TITLE
Use tables for survey and question lists

### DIFF
--- a/surveys/templates/surveys/question_list.html
+++ b/surveys/templates/surveys/question_list.html
@@ -2,11 +2,28 @@
 {% block content %}
 <h1>Vragen voor {{ survey.title }}</h1>
 <a class="btn btn-primary" href="{% url 'question_add' survey.id %}">Nieuwe vraag</a>
-<ul class="mt-3">
-  {% for q in questions %}
-    <li>{{ q.number }}. {{ q.title }} - <a href="{% url 'question_edit' q.id %}">bewerk</a> - <a href="{% url 'question_delete' q.id %}">verwijder</a></li>
-  {% empty %}
-    <li>Geen vragen.</li>
-  {% endfor %}
-</ul>
+<table class="table mt-3">
+  <thead>
+    <tr>
+      <th>Nr</th>
+      <th>Vraag</th>
+      <th>Bewerk</th>
+      <th>Verwijder</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for q in questions %}
+      <tr>
+        <td>{{ q.number }}</td>
+        <td>{{ q.title }}</td>
+        <td><a href="{% url 'question_edit' q.id %}">bewerk</a></td>
+        <td><a href="{% url 'question_delete' q.id %}">verwijder</a></td>
+      </tr>
+    {% empty %}
+      <tr>
+        <td colspan="4">Geen vragen.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/surveys/templates/surveys/survey_list.html
+++ b/surveys/templates/surveys/survey_list.html
@@ -2,11 +2,32 @@
 {% block content %}
 <h1>Enquêtes</h1>
 <a class="btn btn-primary" href="{% url 'survey_add' %}">Nieuwe enquête</a>
-<ul class="mt-3">
-  {% for survey in object_list %}
-    <li>{{ survey.title }} - <a href="{% url 'survey_edit' survey.id %}">bewerk</a> - <a href="{% url 'survey_delete' survey.id %}">verwijder</a> - <a href="{% url 'question_list' survey.id %}">vragen</a> - <a href="{% url 'invite' survey.id %}">uitnodigen</a> - <a href="{% url 'results' survey.id %}">resultaten</a></li>
-  {% empty %}
-    <li>Geen enquêtes.</li>
-  {% endfor %}
-</ul>
+<table class="table mt-3">
+  <thead>
+    <tr>
+      <th>Titel</th>
+      <th>Bewerk</th>
+      <th>Verwijder</th>
+      <th>Vragen</th>
+      <th>Uitnodigen</th>
+      <th>Resultaten</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for survey in object_list %}
+      <tr>
+        <td>{{ survey.title }}</td>
+        <td><a href="{% url 'survey_edit' survey.id %}">bewerk</a></td>
+        <td><a href="{% url 'survey_delete' survey.id %}">verwijder</a></td>
+        <td><a href="{% url 'question_list' survey.id %}">vragen</a></td>
+        <td><a href="{% url 'invite' survey.id %}">uitnodigen</a></td>
+        <td><a href="{% url 'results' survey.id %}">resultaten</a></td>
+      </tr>
+    {% empty %}
+      <tr>
+        <td colspan="6">Geen enquêtes.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace unordered lists with Bootstrap-styled tables in survey and question list templates

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a09fda4b4832697a298608a222f38