### PR TITLE
Render survey forms using table layouts

### DIFF
--- a/surveys/templates/surveys/question_form.html
+++ b/surveys/templates/surveys/question_form.html
@@ -2,8 +2,14 @@
 {% block content %}
 <h1>Vraag</h1>
 <form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn btn-primary" type="submit">Opslaan</button>
+  <table>
+    <tr>
+      <td colspan="2">{% csrf_token %}</td>
+    </tr>
+    {{ form.as_table }}
+    <tr>
+      <td colspan="2"><button class="btn btn-primary" type="submit">Opslaan</button></td>
+    </tr>
+  </table>
 </form>
 {% endblock %}

--- a/surveys/templates/surveys/response_form.html
+++ b/surveys/templates/surveys/response_form.html
@@ -2,8 +2,14 @@
 {% block content %}
 <h1>{{ survey.title }}</h1>
 <form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn btn-primary" type="submit">Verstuur</button>
+  <table>
+    <tr>
+      <td colspan="2">{% csrf_token %}</td>
+    </tr>
+    {{ form.as_table }}
+    <tr>
+      <td colspan="2"><button class="btn btn-primary" type="submit">Verstuur</button></td>
+    </tr>
+  </table>
 </form>
 {% endblock %}

--- a/surveys/templates/surveys/survey_form.html
+++ b/surveys/templates/surveys/survey_form.html
@@ -2,8 +2,14 @@
 {% block content %}
 <h1>Enquête</h1>
 <form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn btn-primary" type="submit">Opslaan</button>
+  <table>
+    <tr>
+      <td colspan="2">{% csrf_token %}</td>
+    </tr>
+    {{ form.as_table }}
+    <tr>
+      <td colspan="2"><button class="btn btn-primary" type="submit">Opslaan</button></td>
+    </tr>
+  </table>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace paragraph-based form rendering with table layout in survey, question, and response forms
- keep CSRF token and submit button inside the table for alignment

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a09fc38808326b19d80fdf508ed6f