### PR TITLE
Add landing page with welcome text

### DIFF
--- a/surveypro/urls.py
+++ b/surveypro/urls.py
@@ -1,8 +1,11 @@
 """Main URL configuration for SurveyPro."""
 from django.contrib import admin
 from django.urls import include, path
+from surveys import views as survey_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', survey_views.home, name='home'),
+    path('surveys/', survey_views.SurveyListView.as_view(), name='survey_list'),
     path('', include('surveys.urls')),
 ]

--- a/surveys/templates/home.html
+++ b/surveys/templates/home.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="p-5 mb-4 bg-light rounded-3">
+  <div class="container-fluid py-5 text-center">
+    <h1 class="display-5 fw-bold">Welcome to SurveyPro</h1>
+    <p class="fs-4">Create and manage surveys with ease.</p>
+    <a class="btn btn-primary btn-lg" href="{% url 'survey_list' %}">View Surveys</a>
+  </div>
+</div>
+{% endblock %}

--- a/surveys/tests/test_views.py
+++ b/surveys/tests/test_views.py
@@ -21,6 +21,10 @@ class SurveyViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Survey.objects.count(), 1)
 
-    def test_login_required(self) -> None:
+    def test_home_page_accessible(self) -> None:
         response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_login_required_for_surveys(self) -> None:
+        response = self.client.get('/surveys/')
         self.assertEqual(response.status_code, 302)

--- a/surveys/urls.py
+++ b/surveys/urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.SurveyListView.as_view(), name='survey_list'),
     path('survey/add/', views.SurveyCreateView.as_view(), name='survey_add'),
     path('survey/<int:pk>/edit/', views.SurveyUpdateView.as_view(), name='survey_edit'),
     path('survey/<int:pk>/delete/', views.SurveyDeleteView.as_view(), name='survey_delete'),

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -16,6 +16,11 @@ from .forms import SurveyForm, QuestionForm, DynamicResponseForm
 from .models import Survey, Question, Option, Invitation, Answer
 
 
+def home(request: HttpRequest) -> HttpResponse:
+    """Render the landing page with a welcome message."""
+    return render(request, 'home.html')
+
+
 class SurveyListView(LoginRequiredMixin, ListView):
     model = Survey
     template_name = 'surveys/survey_list.html'


### PR DESCRIPTION
## Summary
- Add `home` view and template to show a welcome message
- Route `/surveys/` to the existing survey list and expose landing page at `/`
- Adjust tests for new public home page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689a6b0a19f08326a4e840ddcf1f5328